### PR TITLE
[Test for Snyk] Make HttpHeaders cacheable

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpHeadersBuilder.java
@@ -41,6 +41,16 @@ abstract class AbstractHttpHeadersBuilder<SELF extends HttpHeadersBuilder> exten
 
     // Shortcuts
 
+    public final SELF contentLength(long contentLength) {
+        setters().contentLength(contentLength);
+        return self();
+    }
+
+    public final long contentLength() {
+        final HttpHeadersBase getters = getters();
+        return getters != null ? getters.contentLength() : -1;
+    }
+
     @Nullable
     public final MediaType contentType() {
         final HttpHeadersBase getters = getters();

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -423,7 +423,7 @@ public abstract class AbstractHttpRequestBuilder {
         if (content == null || content.isEmpty()) {
             requestHeadersBuilder.remove(CONTENT_LENGTH);
         } else {
-            requestHeadersBuilder.setInt(CONTENT_LENGTH, content.length());
+            requestHeadersBuilder.contentLength(content.length());
         }
         return requestHeadersBuilder.build();
     }

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
@@ -199,7 +199,7 @@ public interface AggregatedHttpRequest extends AggregatedHttpMessage {
         if (content.isEmpty()) {
             builder.remove(CONTENT_LENGTH);
         } else {
-            builder.setInt(CONTENT_LENGTH, content.length());
+            builder.contentLength(content.length());
         }
         headers = builder.build();
         return new DefaultAggregatedHttpRequest(headers, content, trailers);

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
@@ -157,8 +157,7 @@ public interface AggregatedHttpRequest extends AggregatedHttpMessage {
         requireNonNull(mediaType, "mediaType");
         requireNonNull(content, "content");
         requireNonNull(trailers, "trailers");
-        return of(RequestHeaders.builder(method, path)
-                                .contentType(mediaType).build(),
+        return of(RequestHeaders.builder(method, path).contentType(mediaType).build(),
                   content, trailers);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/ContentTooLargeExceptionBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentTooLargeExceptionBuilder.java
@@ -55,12 +55,7 @@ public final class ContentTooLargeExceptionBuilder {
      */
     public ContentTooLargeExceptionBuilder contentLength(HttpHeaders headers) {
         requireNonNull(headers, "headers");
-        final long contentLength = headers.getLong(HttpHeaderNames.CONTENT_LENGTH, -1);
-        if (contentLength >= 0) {
-            this.contentLength = contentLength;
-        } else {
-            this.contentLength = -1;
-        }
+        contentLength = headers.contentLength();
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultHttpHeaders.java
@@ -24,11 +24,6 @@ class DefaultHttpHeaders extends HttpHeadersBase implements HttpHeaders {
 
     static final DefaultHttpHeaders EMPTY_EOS = new DefaultHttpHeaders(true);
 
-    @Nullable
-    private MediaType contentType;
-    @Nullable
-    private ContentDisposition contentDisposition;
-
     /**
      * Creates an empty headers.
      */
@@ -57,27 +52,13 @@ class DefaultHttpHeaders extends HttpHeadersBase implements HttpHeaders {
     @Nullable
     @Override
     public final MediaType contentType() {
-        final MediaType contentType = this.contentType;
-        if (contentType != null) {
-            return contentType;
-        }
-
-        final MediaType newContentType = super.contentType();
-        this.contentType = newContentType;
-        return newContentType;
+        return super.contentType();
     }
 
     @Nullable
     @Override
     public final ContentDisposition contentDisposition() {
-        final ContentDisposition contentDisposition = this.contentDisposition;
-        if (contentDisposition != null) {
-            return contentDisposition;
-        }
-
-        final ContentDisposition newContentDisposition = super.contentDisposition();
-        this.contentDisposition = newContentDisposition;
-        return newContentDisposition;
+        return super.contentDisposition();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
@@ -26,13 +26,7 @@ import javax.annotation.Nullable;
 final class DefaultRequestHeaders extends DefaultHttpHeaders implements RequestHeaders {
 
     @Nullable
-    private HttpMethod method;
-    @Nullable
     private URI uri;
-    @Nullable
-    private List<LanguageRange> acceptLanguages;
-    @Nullable
-    private Cookies cookies;
 
     DefaultRequestHeaders(HttpHeadersBase headers) {
         super(headers);
@@ -59,24 +53,13 @@ final class DefaultRequestHeaders extends DefaultHttpHeaders implements RequestH
     }
 
     @Override
-    @Nullable
     public List<LanguageRange> acceptLanguages() {
-        final List<LanguageRange> acceptLanguages = this.acceptLanguages;
-        if (acceptLanguages != null) {
-            return acceptLanguages;
-        }
-
-        return this.acceptLanguages = super.acceptLanguages();
+        return super.acceptLanguages();
     }
 
     @Override
     public HttpMethod method() {
-        final HttpMethod method = this.method;
-        if (method != null) {
-            return method;
-        }
-
-        return this.method = super.method();
+        return super.method();
     }
 
     @Override
@@ -98,11 +81,7 @@ final class DefaultRequestHeaders extends DefaultHttpHeaders implements RequestH
 
     @Override
     public Cookies cookies() {
-        final Cookies cookies = this.cookies;
-        if (cookies != null) {
-            return cookies;
-        }
-        return this.cookies = cookie();
+        return cookie();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeadersBuilder.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.common;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -25,9 +26,8 @@ import java.util.Locale.LanguageRange;
 
 import javax.annotation.Nullable;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 
 final class DefaultRequestHeadersBuilder extends AbstractHttpHeadersBuilder<RequestHeadersBuilder>
         implements RequestHeadersBuilder {
@@ -131,9 +131,8 @@ final class DefaultRequestHeadersBuilder extends AbstractHttpHeadersBuilder<Requ
     @Override
     public RequestHeadersBuilder acceptLanguages(Iterable<LanguageRange> acceptLanguages) {
         requireNonNull(acceptLanguages, "acceptLanguages");
-        final List<LanguageRange> languageRangeCollection = ImmutableList.copyOf(acceptLanguages);
-        Preconditions.checkArgument(!languageRangeCollection.isEmpty(), "acceptLanguages cannot be empty");
-        setters().acceptLanguages(languageRangeCollection);
+        checkArgument(!Iterables.isEmpty(acceptLanguages), "acceptLanguages cannot be empty");
+        setters().acceptLanguages(acceptLanguages);
         return self();
     }
 
@@ -147,7 +146,7 @@ final class DefaultRequestHeadersBuilder extends AbstractHttpHeadersBuilder<Requ
     @Override
     public RequestHeadersBuilder cookie(Cookie cookie) {
         requireNonNull(cookie, "cookie");
-        return cookies(ImmutableList.of(cookie));
+        return cookies(ImmutableSet.of(cookie));
     }
 
     @Override
@@ -162,7 +161,7 @@ final class DefaultRequestHeadersBuilder extends AbstractHttpHeadersBuilder<Requ
     @Override
     public RequestHeadersBuilder cookies(Iterable<? extends Cookie> cookies) {
         requireNonNull(cookies, "cookie");
-        setters().cookie(ImmutableSet.copyOf(cookies));
+        setters().cookie(cookies);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeadersBuilder.java
@@ -19,11 +19,9 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Locale.LanguageRange;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -133,18 +131,9 @@ final class DefaultRequestHeadersBuilder extends AbstractHttpHeadersBuilder<Requ
     @Override
     public RequestHeadersBuilder acceptLanguages(Iterable<LanguageRange> acceptLanguages) {
         requireNonNull(acceptLanguages, "acceptLanguages");
-        final Collection<LanguageRange> languageRangeCollection;
-        if (acceptLanguages instanceof Collection) {
-            languageRangeCollection = (Collection<LanguageRange>) acceptLanguages;
-        } else {
-            languageRangeCollection = ImmutableList.copyOf(acceptLanguages);
-        }
+        final List<LanguageRange> languageRangeCollection = ImmutableList.copyOf(acceptLanguages);
         Preconditions.checkArgument(!languageRangeCollection.isEmpty(), "acceptLanguages cannot be empty");
-        final String acceptLanguagesValue = languageRangeCollection
-                .stream()
-                .map(it -> (it.getWeight() == 1.0d) ? it.getRange() : it.getRange() + ";q=" + it.getWeight())
-                .collect(Collectors.joining(", "));
-        set(HttpHeaderNames.ACCEPT_LANGUAGE, acceptLanguagesValue);
+        setters().acceptLanguages(languageRangeCollection);
         return self();
     }
 
@@ -173,18 +162,13 @@ final class DefaultRequestHeadersBuilder extends AbstractHttpHeadersBuilder<Requ
     @Override
     public RequestHeadersBuilder cookies(Iterable<? extends Cookie> cookies) {
         requireNonNull(cookies, "cookie");
-        final ImmutableSet.Builder<Cookie> builder = ImmutableSet.builder();
-        for (String cookieHeader : getAll(HttpHeaderNames.COOKIE)) {
-            builder.addAll(Cookie.fromCookieHeader(cookieHeader));
-        }
-        builder.addAll(cookies);
-        set(HttpHeaderNames.COOKIE, Cookie.toCookieHeader(builder.build()));
+        setters().cookie(ImmutableSet.copyOf(cookies));
         return this;
     }
 
     @Override
     public RequestHeadersBuilder cookies(Cookie... cookies) {
         requireNonNull(cookies, "cookie");
-        return cookies(ImmutableList.copyOf(cookies));
+        return cookies(ImmutableSet.copyOf(cookies));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultResponseHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultResponseHeaders.java
@@ -20,11 +20,6 @@ import javax.annotation.Nullable;
 @SuppressWarnings({ "checkstyle:EqualsHashCode", "EqualsAndHashcode" })
 final class DefaultResponseHeaders extends DefaultHttpHeaders implements ResponseHeaders {
 
-    @Nullable
-    private HttpStatus status;
-    @Nullable
-    private Cookies cookies;
-
     DefaultResponseHeaders(HttpHeadersBase headers) {
         super(headers);
     }
@@ -35,21 +30,12 @@ final class DefaultResponseHeaders extends DefaultHttpHeaders implements Respons
 
     @Override
     public HttpStatus status() {
-        final HttpStatus status = this.status;
-        if (status != null) {
-            return status;
-        }
-
-        return this.status = super.status();
+        return super.status();
     }
 
     @Override
     public Cookies cookies() {
-        final Cookies cookies = this.cookies;
-        if (cookies != null) {
-            return cookies;
-        }
-        return this.cookies = setCookie();
+        return setCookie();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultResponseHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultResponseHeadersBuilder.java
@@ -72,7 +72,7 @@ final class DefaultResponseHeadersBuilder
     @Override
     public ResponseHeadersBuilder cookies(Iterable<? extends Cookie> cookies) {
         requireNonNull(cookies, "cookie");
-        setters().setCookie(ImmutableSet.copyOf(cookies));
+        setters().setCookie(cookies);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultResponseHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultResponseHeadersBuilder.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.collect.ImmutableSet;
+
 final class DefaultResponseHeadersBuilder
         extends AbstractHttpHeadersBuilder<ResponseHeadersBuilder>
         implements ResponseHeadersBuilder {
@@ -54,7 +56,7 @@ final class DefaultResponseHeadersBuilder
     @Override
     public ResponseHeadersBuilder cookie(Cookie cookie) {
         requireNonNull(cookie, "cookie");
-        add(HttpHeaderNames.SET_COOKIE, cookie.toCookieHeader());
+        setters().setCookie(ImmutableSet.of(cookie));
         return this;
     }
 
@@ -70,15 +72,14 @@ final class DefaultResponseHeadersBuilder
     @Override
     public ResponseHeadersBuilder cookies(Iterable<? extends Cookie> cookies) {
         requireNonNull(cookies, "cookie");
-        add(HttpHeaderNames.SET_COOKIE, Cookie.toSetCookieHeaders(cookies));
+        setters().setCookie(ImmutableSet.copyOf(cookies));
         return this;
     }
 
     @Override
     public ResponseHeadersBuilder cookies(Cookie... cookies) {
         requireNonNull(cookies, "cookie");
-        add(HttpHeaderNames.SET_COOKIE, Cookie.toSetCookieHeaders(cookies));
-        return this;
+        return cookies(ImmutableSet.copyOf(cookies));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -59,6 +59,7 @@ import com.linecorp.armeria.common.util.Sampler;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.common.util.TransportType;
 import com.linecorp.armeria.internal.common.util.SslContextUtil;
+import com.linecorp.armeria.internal.common.util.StringUtil;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -1347,7 +1348,7 @@ public final class Flags {
     }
 
     private static int getInt(String name, int defaultValue, IntPredicate validator) {
-        return Integer.parseInt(getNormalized(name, String.valueOf(defaultValue), value -> {
+        return Integer.parseInt(getNormalized(name, StringUtil.toString(defaultValue), value -> {
             try {
                 return validator.test(Integer.parseInt(value));
             } catch (Exception e) {
@@ -1358,7 +1359,7 @@ public final class Flags {
     }
 
     private static long getLong(String name, long defaultValue, LongPredicate validator) {
-        return Long.parseLong(getNormalized(name, String.valueOf(defaultValue), value -> {
+        return Long.parseLong(getNormalized(name, StringUtil.toString(defaultValue), value -> {
             try {
                 return validator.test(Long.parseLong(value));
             } catch (Exception e) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderGetters.java
@@ -42,6 +42,13 @@ interface HttpHeaderGetters extends StringMultimapGetters</* IN_NAME */ CharSequ
     boolean isEndOfStream();
 
     /**
+     * Returns the value of the
+     * <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.13">content-length</a> header,
+     * or {@code -1} if this value is not known.
+     */
+    long contentLength();
+
+    /**
      * Returns the parsed {@code "content-type"} header.
      *
      * @return the parsed {@link MediaType} if present and valid, or {@code null} otherwise.

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -156,6 +156,7 @@ class HttpHeadersBase
             return;
         }
 
+        // TODO(ikhoon): Condiser a Map for caching if we have to cache more values.
         if (HttpHeaderNames.METHOD.equals(name)) {
             method = null;
         } else if (HttpHeaderNames.STATUS.equals(name)) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -82,23 +82,27 @@ class HttpHeadersBase
         PROHIBITED_VALUE_CHAR_NAMES['\r'] = "<CR>";
     }
 
-    // Cached values
+    // Cached values for RequestHeaders
     @Nullable
     private HttpMethod method;
     @Nullable
+    private Cookies cookies;
+    @Nullable
+    private List<LanguageRange> acceptLanguages;
+
+    // Cached values for ResponseHeaders
+    @Nullable
     private HttpStatus status;
+    @Nullable
+    private Cookies setCookie;
+
+    // Cached values for HttpHeaders
     @Nullable
     private MediaType contentType;
     @Nullable
     private ContentDisposition contentDisposition;
-    @Nullable
-    private List<LanguageRange> acceptLanguages;
-    @Nullable
-    private Cookies cookies;
-    @Nullable
-    private Cookies setCookie;
-    private boolean isMutating;
 
+    private boolean isMutating;
     private boolean endOfStream;
 
     HttpHeadersBase(int sizeHint) {
@@ -123,32 +127,32 @@ class HttpHeadersBase
         endOfStream = parent.isEndOfStream();
     }
 
-    private void copyCachedValues(HttpHeadersBase parant) {
-        method = parant.method;
-        status = parant.status;
-        contentType = parant.contentType;
-        contentDisposition = parant.contentDisposition;
-        acceptLanguages = parant.acceptLanguages;
-        cookies = parant.cookies;
-        setCookie = parant.setCookie;
+    private void copyCachedValues(HttpHeadersBase parent) {
+        method = parent.method;
+        cookies = parent.cookies;
+        acceptLanguages = parent.acceptLanguages;
+        status = parent.status;
+        setCookie = parent.setCookie;
+        contentType = parent.contentType;
+        contentDisposition = parent.contentDisposition;
     }
 
     @Override
     void onChange(@Nullable AsciiString name) {
         if (isMutating) {
-            // The cached value was update by the shortcut methods itself.
+            // The cached value was update by a shortcut method itself.
             return;
         }
 
         if (name == null) {
             // Invalidate all cached values
             method = null;
+            cookies = null;
+            acceptLanguages = null;
             status = null;
+            setCookie = null;
             contentType = null;
             contentDisposition = null;
-            acceptLanguages = null;
-            cookies = null;
-            setCookie = null;
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBuilder.java
@@ -51,6 +51,11 @@ public interface HttpHeadersBuilder extends HttpHeaderGetters {
     HttpHeadersBuilder endOfStream(boolean endOfStream);
 
     /**
+     * Sets the <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-14.13">content-length</a> header.
+     */
+    HttpHeadersBuilder contentLength(long contentLength);
+
+    /**
      * Sets the {@code "content-type"} header.
      */
     HttpHeadersBuilder contentType(MediaType contentType);

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -233,7 +233,7 @@ public interface HttpRequest extends Request, HttpMessage {
 
         // `content` is not empty.
         headers = headers.toBuilder()
-                         .setInt(CONTENT_LENGTH, contentLength)
+                         .contentLength(contentLength)
                          .build();
 
         if (trailers.isEmpty()) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -323,8 +323,9 @@ public interface HttpResponse extends Response, HttpMessage {
         requireNonNull(mediaType, "mediaType");
         requireNonNull(content, "content");
 
-        final ResponseHeaders headers = ResponseHeaders.of(status,
-                                                           HttpHeaderNames.CONTENT_TYPE, mediaType);
+        final ResponseHeaders headers = ResponseHeaders.builder(status)
+                                                       .contentType(mediaType)
+                                                       .build();
         return of(headers, content, trailers);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeaders.java
@@ -45,7 +45,7 @@ public interface RequestHeaders extends HttpHeaders, RequestHeaderGetters {
         requireNonNull(method, "method");
         requireNonNull(path, "path");
         return builder().method(method)
-                        .add(HttpHeaderNames.PATH, path);
+                        .path(path);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeaders.java
@@ -44,7 +44,7 @@ public interface RequestHeaders extends HttpHeaders, RequestHeaderGetters {
     static RequestHeadersBuilder builder(HttpMethod method, String path) {
         requireNonNull(method, "method");
         requireNonNull(path, "path");
-        return builder().add(HttpHeaderNames.METHOD, method.name())
+        return builder().method(method)
                         .add(HttpHeaderNames.PATH, path);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeadersBuilder.java
@@ -135,6 +135,9 @@ public interface RequestHeadersBuilder extends HttpHeadersBuilder, RequestHeader
     RequestHeadersBuilder endOfStream(boolean endOfStream);
 
     @Override
+    RequestHeadersBuilder contentLength(long contentLength);
+
+    @Override
     RequestHeadersBuilder contentType(MediaType contentType);
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/ResponseHeaderGetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ResponseHeaderGetters.java
@@ -30,7 +30,8 @@ interface ResponseHeaderGetters extends HttpHeaderGetters {
     HttpStatus status();
 
     /**
-     * Returns the parsed <a href="https://datatracker.ietf.org/doc/html/rfc6265#section-4.1">set-cookie</a> header.
+     * Returns the parsed
+     * <a href="https://datatracker.ietf.org/doc/html/rfc6265#section-4.1">set-cookie</a> header.
      *
      * @return a {@link Cookies} or an empty {@link Cookies} if there is no such header.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/ResponseHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ResponseHeaders.java
@@ -50,7 +50,7 @@ public interface ResponseHeaders extends HttpHeaders, ResponseHeaderGetters {
      */
     static ResponseHeadersBuilder builder(HttpStatus status) {
         requireNonNull(status, "status");
-        return builder().add(HttpHeaderNames.STATUS, status.codeAsText());
+        return builder().status(status);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/ResponseHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ResponseHeadersBuilder.java
@@ -67,6 +67,9 @@ public interface ResponseHeadersBuilder extends HttpHeadersBuilder, ResponseHead
     ResponseHeadersBuilder endOfStream(boolean endOfStream);
 
     @Override
+    ResponseHeadersBuilder contentLength(long contentLength);
+
+    @Override
     ResponseHeadersBuilder contentType(MediaType contentType);
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/StringMultimap.java
+++ b/core/src/main/java/com/linecorp/armeria/common/StringMultimap.java
@@ -633,6 +633,10 @@ abstract class StringMultimap<IN_NAME extends CharSequence, NAME extends IN_NAME
     }
 
     final void add(IN_NAME name, Iterable<String> values) {
+        add(name, values, true);
+    }
+
+    final void add(IN_NAME name, Iterable<String> values, boolean notifyChange) {
         final NAME normalizedName = normalizeName(name);
         requireNonNull(values, "values");
         final int h = hashName(normalizedName);
@@ -641,8 +645,11 @@ abstract class StringMultimap<IN_NAME extends CharSequence, NAME extends IN_NAME
             requireNonNullElement(values, v);
             add0(h, i, normalizedName, v, false);
         }
-        onChange(normalizedName);
+        if (notifyChange) {
+            onChange(normalizedName);
+        }
     }
+
 
     final void add(IN_NAME name, String... values) {
         final NAME normalizedName = normalizeName(name);
@@ -720,11 +727,17 @@ abstract class StringMultimap<IN_NAME extends CharSequence, NAME extends IN_NAME
     }
 
     final void set(IN_NAME name, String value) {
+        set(name, value, true);
+    }
+
+    final void set(IN_NAME name, String value, boolean notifyChange) {
         final NAME normalizedName = normalizeName(name);
         requireNonNull(value, "value");
         final int h = hashName(normalizedName);
         final int i = index(h);
-        remove0(h, i, normalizedName, true);
+        if (notifyChange) {
+            remove0(h, i, normalizedName, notifyChange);
+        }
         add0(h, i, normalizedName, value, false);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/StringMultimap.java
+++ b/core/src/main/java/com/linecorp/armeria/common/StringMultimap.java
@@ -650,7 +650,6 @@ abstract class StringMultimap<IN_NAME extends CharSequence, NAME extends IN_NAME
         }
     }
 
-
     final void add(IN_NAME name, String... values) {
         final NAME normalizedName = normalizeName(name);
         requireNonNull(values, "values");
@@ -735,9 +734,7 @@ abstract class StringMultimap<IN_NAME extends CharSequence, NAME extends IN_NAME
         requireNonNull(value, "value");
         final int h = hashName(normalizedName);
         final int i = index(h);
-        if (notifyChange) {
-            remove0(h, i, normalizedName, notifyChange);
-        }
+        remove0(h, i, normalizedName, notifyChange);
         add0(h, i, normalizedName, value, false);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/StringValueConverter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/StringValueConverter.java
@@ -37,6 +37,8 @@ import java.util.Date;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.armeria.internal.common.util.StringUtil;
+
 import io.netty.handler.codec.DateFormatter;
 import io.netty.handler.codec.ValueConverter;
 
@@ -97,12 +99,12 @@ final class StringValueConverter implements ValueConverter<String> {
 
     @Override
     public String convertInt(int value) {
-        return String.valueOf(value);
+        return StringUtil.toString(value);
     }
 
     @Override
     public String convertLong(long value) {
-        return String.valueOf(value);
+        return StringUtil.toString(value);
     }
 
     @Override
@@ -132,7 +134,7 @@ final class StringValueConverter implements ValueConverter<String> {
 
     @Override
     public String convertByte(byte value) {
-        return String.valueOf(value & 0xFF);
+        return StringUtil.toString(value & 0xFF);
     }
 
     @Override
@@ -150,7 +152,7 @@ final class StringValueConverter implements ValueConverter<String> {
 
     @Override
     public String convertShort(short value) {
-        return String.valueOf(value);
+        return StringUtil.toString(value);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -44,6 +44,7 @@ import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.internal.common.util.StringUtil;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -75,7 +76,7 @@ public enum BuiltInProperty {
      */
     REMOTE_PORT("remote.port", log -> {
         final InetSocketAddress addr = log.context().remoteAddress();
-        return addr != null ? String.valueOf(addr.getPort()) : null;
+        return addr != null ? StringUtil.toString(addr.getPort()) : null;
     }),
     /**
      * {@code "local.host"} - the host name part of the local socket address. Unavailable if the connection
@@ -99,7 +100,7 @@ public enum BuiltInProperty {
      */
     LOCAL_PORT("local.port", log -> {
         final InetSocketAddress addr = log.context().localAddress();
-        return addr != null ? String.valueOf(addr.getPort()) : null;
+        return addr != null ? StringUtil.toString(addr.getPort()) : null;
     }),
     /**
      * {@code "client.ip"} - the IP address who initiated a request. Unavailable if the connection is not
@@ -205,7 +206,7 @@ public enum BuiltInProperty {
      */
     REQ_CONTENT_LENGTH("req.content_length", log -> {
         if (log.isAvailable(RequestLogProperty.REQUEST_LENGTH)) {
-            return String.valueOf(log.requestLength());
+            return StringUtil.toString(log.requestLength());
         }
         return null;
     }),
@@ -257,7 +258,7 @@ public enum BuiltInProperty {
      */
     RES_CONTENT_LENGTH("res.content_length", log -> {
         if (log.isAvailable(RequestLogProperty.RESPONSE_LENGTH)) {
-            return String.valueOf(log.responseLength());
+            return StringUtil.toString(log.responseLength());
         }
         return null;
     }),

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -615,7 +615,7 @@ public final class ArmeriaHttpUtil {
         final io.netty.handler.codec.http.HttpHeaders inHeaders = in.headers();
         final ResponseHeadersBuilder out = ResponseHeaders.builder();
         out.sizeHint(inHeaders.size());
-        out.add(HttpHeaderNames.STATUS, HttpStatus.valueOf(in.status().code()).codeAsText());
+        out.status(HttpStatus.valueOf(in.status().code()));
         // Add the HTTP headers which have not been consumed above
         toArmeria(inHeaders, out);
         return out.build();

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -1070,7 +1070,7 @@ public final class ArmeriaHttpUtil {
 
         if (!headers.contains(HttpHeaderNames.CONTENT_LENGTH) || !content.isEmpty()) {
             return headers.toBuilder()
-                          .setInt(HttpHeaderNames.CONTENT_LENGTH, content.length())
+                          .contentLength(content.length())
                           .build();
         }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/StringUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/StringUtil.java
@@ -48,6 +48,13 @@ public final class StringUtil {
         return Integer.toString(num);
     }
 
+    public static String toString(long num) {
+        if (num >= MIN_NUM && num <= MAX_NUM) {
+            return intToString[(int) (num + MAX_NUM)];
+        }
+        return Long.toString(num);
+    }
+
     public static Boolean toBoolean(String s, boolean errorOnFailure) {
         final Boolean result = stringToBoolean.get(Ascii.toLowerCase(s));
         if (result != null) {

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -336,7 +336,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
         final ResponseHeaders headers =
                 ResponseHeaders.builder()
                                .status(status.code())
-                               .setObject(HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8)
+                               .contentType(MediaType.PLAIN_TEXT_UTF_8)
                                .setInt(HttpHeaderNames.CONTENT_LENGTH, data.length())
                                .build();
         writer.writeHeaders(id, 1, headers, false);

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -337,7 +337,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                 ResponseHeaders.builder()
                                .status(status.code())
                                .contentType(MediaType.PLAIN_TEXT_UTF_8)
-                               .setInt(HttpHeaderNames.CONTENT_LENGTH, data.length())
+                               .contentLength(data.length())
                                .build();
         writer.writeHeaders(id, 1, headers, false);
         writer.writeData(id, 1, data, true).addListener(ChannelFutureListener.CLOSE);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -631,7 +631,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         if (req.method() == HttpMethod.HEAD || headers.status().isContentAlwaysEmpty()) {
             return;
         }
-        headers.setInt(HttpHeaderNames.CONTENT_LENGTH, contentLength);
+        headers.contentLength(contentLength);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -539,8 +539,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         }
 
         respond(ctx, reqCtx,
-                ResponseHeaders.builder(status)
-                               .addObject(HttpHeaderNames.CONTENT_TYPE, ERROR_CONTENT_TYPE),
+                ResponseHeaders.builder(status).contentType(ERROR_CONTENT_TYPE),
                 resContent, cause);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingResult.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingResult.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
+import com.linecorp.armeria.internal.common.util.StringUtil;
 
 /**
  * The result returned by {@link Route#apply(RoutingContext, boolean)}.
@@ -203,7 +204,7 @@ public final class RoutingResult {
     @Override
     public String toString() {
         if (isPresent()) {
-            String score = String.valueOf(this.score);
+            String score = StringUtil.toString(this.score);
             if (hasHighestScore()) {
                 score += " (highest)";
             } else if (hasLowestScore()) {

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncodedResponse.java
@@ -202,7 +202,10 @@ final class HttpEncodedResponse extends FilteredHttpResponse {
         // We switch to chunked encoding and compress the response if it's reasonably
         // large or the content length is unknown because the compression savings should
         // outweigh the chunked encoding overhead.
-        final long contentLength = headers.getLong(HttpHeaderNames.CONTENT_LENGTH, Long.MAX_VALUE);
+        long contentLength = headers.contentLength();
+        if (contentLength == -1) {
+            contentLength = Long.MAX_VALUE;
+        }
         return contentLength >= minBytesToForceChunkedAndEncoding;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
@@ -171,7 +171,7 @@ public abstract class AbstractHttpFile implements HttpFile {
     private ResponseHeaders addCommonHeaders(ResponseHeadersBuilder headers, HttpFileAttributes attrs,
                                              @Nullable String etag) {
         if (contentType != null) {
-            headers.set(HttpHeaderNames.CONTENT_TYPE, contentType.toString());
+            headers.contentType(contentType);
         }
         if (dateEnabled) {
             headers.setTimeMillis(HttpHeaderNames.DATE, clock.millis());

--- a/core/src/main/java/com/linecorp/armeria/server/streaming/JsonLines.java
+++ b/core/src/main/java/com/linecorp/armeria/server/streaming/JsonLines.java
@@ -35,7 +35,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -91,8 +90,9 @@ public final class JsonLines {
     /**
      * A default {@link ResponseHeaders} of JSON Lines.
      */
-    private static final ResponseHeaders defaultHttpHeaders =
-            ResponseHeaders.of(HttpStatus.OK, HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_LINES);
+    private static final ResponseHeaders defaultHttpHeaders = ResponseHeaders.builder(HttpStatus.OK)
+                                                                             .contentType(MediaType.JSON_LINES)
+                                                                             .build();
 
     /**
      * Returns a newly created JSON Lines response from the specified {@link Publisher}.
@@ -357,7 +357,7 @@ public final class JsonLines {
         final MediaType contentType = headers.contentType();
         if (contentType == null) {
             return headers.toBuilder()
-                          .add(HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_LINES.toString())
+                          .contentType(MediaType.JSON_LINES)
                           .build();
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
+++ b/core/src/main/java/com/linecorp/armeria/server/streaming/JsonTextSequences.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -94,8 +93,9 @@ public final class JsonTextSequences {
     /**
      * A default {@link ResponseHeaders} of JSON Text Sequences.
      */
-    private static final ResponseHeaders defaultHttpHeaders =
-            ResponseHeaders.of(HttpStatus.OK, HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_SEQ);
+    private static final ResponseHeaders defaultHttpHeaders = ResponseHeaders.builder(HttpStatus.OK)
+                                                                             .contentType(MediaType.JSON_SEQ)
+                                                                             .build();
 
     /**
      * Creates a new JSON Text Sequences from the specified {@link Publisher}.
@@ -359,7 +359,7 @@ public final class JsonTextSequences {
         final MediaType contentType = headers.contentType();
         if (contentType == null) {
             return headers.toBuilder()
-                          .add(HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_SEQ.toString())
+                          .contentType(MediaType.JSON_SEQ)
                           .build();
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/streaming/ServerSentEvents.java
+++ b/core/src/main/java/com/linecorp/armeria/server/streaming/ServerSentEvents.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -80,8 +79,9 @@ public final class ServerSentEvents {
      * A default {@link ResponseHeaders} of Server-Sent Events.
      */
     private static final ResponseHeaders defaultHttpHeaders =
-            ResponseHeaders.of(HttpStatus.OK,
-                               HttpHeaderNames.CONTENT_TYPE, MediaType.EVENT_STREAM);
+            ResponseHeaders.builder(HttpStatus.OK)
+                           .contentType(MediaType.EVENT_STREAM)
+                           .build();
 
     /**
      * Creates a new Server-Sent Events stream from the specified {@link Publisher}.
@@ -316,7 +316,7 @@ public final class ServerSentEvents {
         final MediaType contentType = headers.contentType();
         if (contentType == null) {
             return headers.toBuilder()
-                          .add(HttpHeaderNames.CONTENT_TYPE, MediaType.EVENT_STREAM.toString())
+                          .contentType(MediaType.EVENT_STREAM)
                           .build();
         }
 

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeaderCachedValuesTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeaderCachedValuesTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Locale.LanguageRange;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+class HttpHeaderCachedValuesTest {
+
+    @Test
+    void method() {
+        // Initialize with the shortcut method
+        final RequestHeadersBuilder builder = RequestHeaders.builder(HttpMethod.GET, "/foo");
+        assertThat(builder.get(HttpHeaderNames.METHOD)).isEqualTo("GET");
+        assertThat(builder.method()).isEqualTo(HttpMethod.GET);
+
+        // Mutate with the non-shortcut method
+        builder.set(HttpHeaderNames.METHOD, "POST");
+        assertThat(builder.get(HttpHeaderNames.METHOD)).isEqualTo("POST");
+        // Make sure that the cached value is invalidated
+        assertThat(builder.method()).isEqualTo(HttpMethod.POST);
+
+        // Mutate with the shortcut method
+        builder.method(HttpMethod.DELETE);
+        // Make sure that the container value is updated
+        assertThat(builder.get(HttpHeaderNames.METHOD)).isEqualTo("DELETE");
+        assertThat(builder.method()).isEqualTo(HttpMethod.DELETE);
+
+        final RequestHeaders headers = builder.build();
+        assertThat(headers.method()).isEqualTo(HttpMethod.DELETE);
+
+        final RequestHeaders headers2 = headers.toBuilder().set(HttpHeaderNames.METHOD, "PATCH").build();
+        assertThat(headers2.method()).isEqualTo(HttpMethod.PATCH);
+        // The original value is not changed.
+        assertThat(headers.method()).isEqualTo(HttpMethod.DELETE);
+    }
+
+    @Test
+    void status() {
+        // Initialize with the shortcut method
+        final ResponseHeadersBuilder builder = ResponseHeaders.builder(HttpStatus.OK);
+        assertThat(builder.get(HttpHeaderNames.STATUS)).isEqualTo("200");
+        assertThat(builder.status()).isEqualTo(HttpStatus.OK);
+
+        // Mutate with the non-shortcut method
+        builder.set(HttpHeaderNames.STATUS, "400");
+        assertThat(builder.get(HttpHeaderNames.STATUS)).isEqualTo("400");
+        // Make sure that the the cached value is invalidated
+        assertThat(builder.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+        // Mutate with the shortcut method
+        builder.status(HttpStatus.INTERNAL_SERVER_ERROR);
+        // Make sure that the the container value is updated
+        assertThat(builder.get(HttpHeaderNames.STATUS)).isEqualTo("500");
+        assertThat(builder.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        final ResponseHeaders headers = builder.build();
+        assertThat(headers.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        final ResponseHeaders headers2 = headers.toBuilder().set(HttpHeaderNames.STATUS, "303").build();
+        assertThat(headers2.status()).isEqualTo(HttpStatus.SEE_OTHER);
+        // The original value is not changed.
+        assertThat(headers.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    void contentType() {
+        // Initialize with the shortcut method
+        final ResponseHeadersBuilder builder = ResponseHeaders.builder(HttpStatus.OK)
+                                                              .contentType(MediaType.PLAIN_TEXT);
+        assertThat(builder.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(MediaType.PLAIN_TEXT.toString());
+        assertThat(builder.contentType()).isEqualTo(MediaType.PLAIN_TEXT);
+
+        // Mutate with the non-shortcut method
+        builder.set(HttpHeaderNames.CONTENT_TYPE, MediaType.JSON.toString());
+        assertThat(builder.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(MediaType.JSON.toString());
+        // Make sure that the the cached value is invalidated
+        assertThat(builder.contentType()).isEqualTo(MediaType.JSON);
+
+        // Mutate with the shortcut method
+        builder.contentType(MediaType.PROTOBUF);
+        // Make sure that the the container value is updated
+        assertThat(builder.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(MediaType.PROTOBUF.toString());
+        assertThat(builder.contentType()).isEqualTo(MediaType.PROTOBUF);
+
+        final ResponseHeaders headers = builder.build();
+        assertThat(headers.contentType()).isEqualTo(MediaType.PROTOBUF);
+
+        final ResponseHeaders headers2 =
+                headers.toBuilder().setObject(HttpHeaderNames.CONTENT_TYPE, MediaType.OCTET_STREAM).build();
+        assertThat(headers2.contentType()).isEqualTo(MediaType.OCTET_STREAM);
+        // The original value is not changed.
+        assertThat(headers.contentType()).isEqualTo(MediaType.PROTOBUF);
+    }
+
+    @Test
+    void contentDisposition() {
+        // Initialize with the shortcut method
+        final ContentDisposition fooContentDisposition = ContentDisposition.of("foo");
+        final HttpHeadersBuilder builder = HttpHeaders.builder()
+                                                      .contentDisposition(fooContentDisposition);
+        assertThat(builder.get(HttpHeaderNames.CONTENT_DISPOSITION))
+                .isEqualTo(fooContentDisposition.asHeaderValue());
+        assertThat(builder.contentDisposition()).isSameAs(fooContentDisposition);
+
+        // Mutate with the non-shortcut method
+        final ContentDisposition fooContentDisposition2 = ContentDisposition.of("foo");
+        builder.setObject(HttpHeaderNames.CONTENT_DISPOSITION, fooContentDisposition2);
+        assertThat(builder.get(HttpHeaderNames.CONTENT_DISPOSITION))
+                .isEqualTo(fooContentDisposition2.asHeaderValue());
+        // Make sure that the the cached value is invalidated
+        assertThat(builder.contentDisposition()).isEqualTo(fooContentDisposition2);
+        assertThat(builder.contentDisposition()).isNotSameAs(fooContentDisposition2);
+
+        // Remove a value with the non-shortcut method
+        builder.remove(HttpHeaderNames.CONTENT_DISPOSITION);
+        assertThat(builder.contentDisposition()).isNull();
+
+        // Mutate with the shortcut method
+        final ContentDisposition bazContentDisposition = ContentDisposition.of("baz");
+        builder.contentDisposition(bazContentDisposition);
+        // Make sure that the the container value is updated
+        assertThat(builder.get(HttpHeaderNames.CONTENT_DISPOSITION))
+                .isEqualTo(bazContentDisposition.asHeaderValue());
+        assertThat(builder.contentDisposition()).isSameAs(bazContentDisposition);
+
+        final HttpHeaders headers = builder.build();
+        assertThat(headers.contentDisposition()).isSameAs(bazContentDisposition);
+
+        final ContentDisposition quxContentDisposition = ContentDisposition.of("qux");
+        final HttpHeaders headers2 =
+                headers.toBuilder()
+                       .setObject(HttpHeaderNames.CONTENT_DISPOSITION, quxContentDisposition)
+                       .build();
+        assertThat(headers2.contentDisposition()).isEqualTo(quxContentDisposition);
+        // The original value is not changed.
+        assertThat(headers.contentDisposition()).isSameAs(bazContentDisposition);
+    }
+
+    @Test
+    void acceptLanguages() {
+        // Initialize with the shortcut method
+        final RequestHeadersBuilder builder = RequestHeaders.builder(HttpMethod.GET, "/foo");
+        final ImmutableList<LanguageRange> languages =
+                ImmutableList.of(new LanguageRange("zh-TW", 0.8),
+                                 new LanguageRange("de-us", 0.5));
+        builder.acceptLanguages(languages);
+        assertThat(builder.acceptLanguages()).isEqualTo(languages);
+
+        // Mutate with the non-shortcut method
+        builder.set(HttpHeaderNames.ACCEPT_LANGUAGE, "zh-tw;q=1.0, de-us;q=0.5");
+        assertThat(builder.get(HttpHeaderNames.ACCEPT_LANGUAGE)).isEqualTo("zh-tw;q=1.0, de-us;q=0.5");
+        // Make sure that the cached value is invalidated
+        assertThat(builder.acceptLanguages()).containsExactly(new LanguageRange("zh-TW", 1.0),
+                                                              new LanguageRange("de-us", 0.5));
+
+        // Mutate with the shortcut method
+        final LanguageRange englishUS = new LanguageRange("en-US", 0.9);
+        builder.acceptLanguages(englishUS);
+        // Make sure that the container value is updated
+        assertThat(builder.get(HttpHeaderNames.ACCEPT_LANGUAGE)).isEqualTo("en-us;q=0.9");
+        assertThat(builder.acceptLanguages()).hasSize(1);
+        assertThat(builder.acceptLanguages().get(0)).isSameAs(englishUS);
+
+        final RequestHeaders headers = builder.build();
+        assertThat(headers.acceptLanguages().get(0)).isSameAs(englishUS);
+    }
+
+    @Test
+    void cookies() {
+        // Initialize with the shortcut method
+        final RequestHeadersBuilder builder = RequestHeaders.builder(HttpMethod.GET, "/foo");
+        final Cookie foo = Cookie.of("foo", "1");
+        builder.cookies(foo);
+        assertThat(builder.cookies()).hasSize(1);
+        assertThat(builder.cookies().toArray()[0]).isSameAs(foo);
+
+        // Mutate with the non-shortcut method
+        final Cookie bar = Cookie.of("bar", "2");
+        final Cookie baz = Cookie.of("baz", "3");
+        final List<String> cookies2 = ImmutableList.of(bar.toCookieHeader(),
+                                                       baz.toCookieHeader());
+        builder.add(HttpHeaderNames.COOKIE, cookies2);
+        // Make sure that the cached value is invalidated
+        assertThat(builder.cookies()).hasSize(3);
+        final List<Cookie> cookies3 = ImmutableList.copyOf(builder.cookies());
+        assertThat(cookies3.get(0)).isEqualTo(foo);
+        assertThat(cookies3.get(0)).isNotSameAs(foo);
+        assertThat(cookies3.get(1)).isEqualTo(bar);
+        assertThat(cookies3.get(2)).isEqualTo(baz);
+
+        assertThat(builder.getAll(HttpHeaderNames.COOKIE))
+                .containsExactly(foo.toCookieHeader(), bar.toSetCookieHeader(), baz.toCookieHeader());
+
+        // Mutate with the shortcut method
+        final Cookie qux = Cookie.of("qux", "4");
+        builder.cookies(qux);
+        // Make sure that the container value is updated
+        assertThat(builder.get(HttpHeaderNames.COOKIE))
+                .isEqualTo(Cookie.toCookieHeader(foo, bar, baz, qux));
+        final Cookies cookies4 = builder.cookies();
+        assertThat(ImmutableList.copyOf(cookies4).get(3)).isSameAs(qux);
+
+        final RequestHeaders headers = builder.build();
+        assertThat(headers.cookies()).isSameAs(cookies4);
+        assertThat(headers.get(HttpHeaderNames.COOKIE)).isEqualTo(Cookie.toCookieHeader(cookies4));
+    }
+
+    @Test
+    void setCookies() {
+        // Initialize with the shortcut method
+        final ResponseHeadersBuilder builder = ResponseHeaders.builder(HttpStatus.OK);
+        final Cookie foo = Cookie.of("foo", "1");
+        builder.cookies(foo);
+        assertThat(builder.cookies()).hasSize(1);
+        assertThat(builder.cookies().toArray()[0]).isSameAs(foo);
+
+        // Mutate with the non-shortcut method
+        final Cookie bar = Cookie.of("bar", "2");
+        final Cookie baz = Cookie.of("baz", "3");
+        final List<String> cookies2 = ImmutableList.of(bar.toSetCookieHeader(),
+                                                       baz.toSetCookieHeader());
+        builder.add(HttpHeaderNames.SET_COOKIE, cookies2);
+        // Make sure that the cached value is invalidated
+        assertThat(builder.cookies()).hasSize(3);
+        final List<Cookie> cookies3 = ImmutableList.copyOf(builder.cookies());
+        assertThat(cookies3.get(0)).isEqualTo(foo);
+        assertThat(cookies3.get(0)).isNotSameAs(foo);
+        assertThat(cookies3.get(1)).isEqualTo(bar);
+        assertThat(cookies3.get(2)).isEqualTo(baz);
+
+        assertThat(builder.getAll(HttpHeaderNames.SET_COOKIE))
+                .containsExactly(foo.toSetCookieHeader(), bar.toSetCookieHeader(), baz.toSetCookieHeader());
+
+        // Mutate with the shortcut method
+        final Cookie qux = Cookie.of("qux", "4");
+        builder.cookies(qux);
+        // Make sure that the container value is updated
+        assertThat(builder.getAll(HttpHeaderNames.SET_COOKIE))
+                .containsExactly(foo.toSetCookieHeader(), bar.toSetCookieHeader(),
+                                 baz.toSetCookieHeader(), qux.toSetCookieHeader());
+        final Cookies cookies4 = builder.cookies();
+        assertThat(ImmutableList.copyOf(cookies4).get(3)).isSameAs(qux);
+
+        final ResponseHeaders headers = builder.build();
+        assertThat(headers.cookies()).isSameAs(cookies4);
+        assertThat(headers.getAll(HttpHeaderNames.SET_COOKIE)).isEqualTo(Cookie.toSetCookieHeaders(cookies4));
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeaderCachedValuesTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeaderCachedValuesTest.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.common;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.Locale.LanguageRange;
 
 import org.junit.jupiter.api.Test;
 
@@ -65,12 +64,12 @@ class HttpHeaderCachedValuesTest {
         // Mutate with the non-shortcut method
         builder.set(HttpHeaderNames.STATUS, "400");
         assertThat(builder.get(HttpHeaderNames.STATUS)).isEqualTo("400");
-        // Make sure that the the cached value is invalidated
+        // Make sure that the cached value is invalidated
         assertThat(builder.status()).isEqualTo(HttpStatus.BAD_REQUEST);
 
         // Mutate with the shortcut method
         builder.status(HttpStatus.INTERNAL_SERVER_ERROR);
-        // Make sure that the the container value is updated
+        // Make sure that the container value is updated
         assertThat(builder.get(HttpHeaderNames.STATUS)).isEqualTo("500");
         assertThat(builder.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
 
@@ -94,12 +93,12 @@ class HttpHeaderCachedValuesTest {
         // Mutate with the non-shortcut method
         builder.set(HttpHeaderNames.CONTENT_TYPE, MediaType.JSON.toString());
         assertThat(builder.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(MediaType.JSON.toString());
-        // Make sure that the the cached value is invalidated
+        // Make sure that the cached value is invalidated
         assertThat(builder.contentType()).isEqualTo(MediaType.JSON);
 
         // Mutate with the shortcut method
         builder.contentType(MediaType.PROTOBUF);
-        // Make sure that the the container value is updated
+        // Make sure that the container value is updated
         assertThat(builder.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(MediaType.PROTOBUF.toString());
         assertThat(builder.contentType()).isEqualTo(MediaType.PROTOBUF);
 
@@ -114,76 +113,42 @@ class HttpHeaderCachedValuesTest {
     }
 
     @Test
-    void contentDisposition() {
+    void contentLength() {
         // Initialize with the shortcut method
-        final ContentDisposition fooContentDisposition = ContentDisposition.of("foo");
         final HttpHeadersBuilder builder = HttpHeaders.builder()
-                                                      .contentDisposition(fooContentDisposition);
-        assertThat(builder.get(HttpHeaderNames.CONTENT_DISPOSITION))
-                .isEqualTo(fooContentDisposition.asHeaderValue());
-        assertThat(builder.contentDisposition()).isSameAs(fooContentDisposition);
+                                                      .contentLength(1000);
+        assertThat(builder.get(HttpHeaderNames.CONTENT_LENGTH))
+                .isEqualTo("1000");
+        assertThat(builder.contentLength()).isEqualTo(1000);
 
         // Mutate with the non-shortcut method
-        final ContentDisposition fooContentDisposition2 = ContentDisposition.of("foo");
-        builder.setObject(HttpHeaderNames.CONTENT_DISPOSITION, fooContentDisposition2);
-        assertThat(builder.get(HttpHeaderNames.CONTENT_DISPOSITION))
-                .isEqualTo(fooContentDisposition2.asHeaderValue());
-        // Make sure that the the cached value is invalidated
-        assertThat(builder.contentDisposition()).isEqualTo(fooContentDisposition2);
-        assertThat(builder.contentDisposition()).isNotSameAs(fooContentDisposition2);
+        builder.setLong(HttpHeaderNames.CONTENT_LENGTH, 2000);
+        assertThat(builder.get(HttpHeaderNames.CONTENT_LENGTH))
+                .isEqualTo("2000");
+        // Make sure that the cached value is invalidated
+        assertThat(builder.contentLength()).isEqualTo(2000);
 
         // Remove a value with the non-shortcut method
-        builder.remove(HttpHeaderNames.CONTENT_DISPOSITION);
-        assertThat(builder.contentDisposition()).isNull();
+        builder.remove(HttpHeaderNames.CONTENT_LENGTH);
+        assertThat(builder.contentLength()).isEqualTo(-1);
 
         // Mutate with the shortcut method
-        final ContentDisposition bazContentDisposition = ContentDisposition.of("baz");
-        builder.contentDisposition(bazContentDisposition);
-        // Make sure that the the container value is updated
-        assertThat(builder.get(HttpHeaderNames.CONTENT_DISPOSITION))
-                .isEqualTo(bazContentDisposition.asHeaderValue());
-        assertThat(builder.contentDisposition()).isSameAs(bazContentDisposition);
+        builder.contentLength(3000);
+        // Make sure that the container value is updated
+        assertThat(builder.get(HttpHeaderNames.CONTENT_LENGTH))
+                .isEqualTo("3000");
+        assertThat(builder.contentLength()).isEqualTo(3000);
 
         final HttpHeaders headers = builder.build();
-        assertThat(headers.contentDisposition()).isSameAs(bazContentDisposition);
+        assertThat(headers.contentLength()).isEqualTo(3000);
 
-        final ContentDisposition quxContentDisposition = ContentDisposition.of("qux");
         final HttpHeaders headers2 =
                 headers.toBuilder()
-                       .setObject(HttpHeaderNames.CONTENT_DISPOSITION, quxContentDisposition)
+                       .setObject(HttpHeaderNames.CONTENT_LENGTH, 4000)
                        .build();
-        assertThat(headers2.contentDisposition()).isEqualTo(quxContentDisposition);
-        // The original value is not changed.
-        assertThat(headers.contentDisposition()).isSameAs(bazContentDisposition);
-    }
-
-    @Test
-    void acceptLanguages() {
-        // Initialize with the shortcut method
-        final RequestHeadersBuilder builder = RequestHeaders.builder(HttpMethod.GET, "/foo");
-        final ImmutableList<LanguageRange> languages =
-                ImmutableList.of(new LanguageRange("zh-TW", 0.8),
-                                 new LanguageRange("de-us", 0.5));
-        builder.acceptLanguages(languages);
-        assertThat(builder.acceptLanguages()).isEqualTo(languages);
-
-        // Mutate with the non-shortcut method
-        builder.set(HttpHeaderNames.ACCEPT_LANGUAGE, "zh-tw;q=1.0, de-us;q=0.5");
-        assertThat(builder.get(HttpHeaderNames.ACCEPT_LANGUAGE)).isEqualTo("zh-tw;q=1.0, de-us;q=0.5");
-        // Make sure that the cached value is invalidated
-        assertThat(builder.acceptLanguages()).containsExactly(new LanguageRange("zh-TW", 1.0),
-                                                              new LanguageRange("de-us", 0.5));
-
-        // Mutate with the shortcut method
-        final LanguageRange englishUS = new LanguageRange("en-US", 0.9);
-        builder.acceptLanguages(englishUS);
-        // Make sure that the container value is updated
-        assertThat(builder.get(HttpHeaderNames.ACCEPT_LANGUAGE)).isEqualTo("en-us;q=0.9");
-        assertThat(builder.acceptLanguages()).hasSize(1);
-        assertThat(builder.acceptLanguages().get(0)).isSameAs(englishUS);
-
-        final RequestHeaders headers = builder.build();
-        assertThat(headers.acceptLanguages().get(0)).isSameAs(englishUS);
+        assertThat(headers2.contentLength()).isEqualTo(4000);
+        // Make sure that the original value is not changed.
+        assertThat(headers.contentLength()).isEqualTo(3000);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/StringMultimapDerivedApiConsistencyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/StringMultimapDerivedApiConsistencyTest.java
@@ -60,6 +60,7 @@ class StringMultimapDerivedApiConsistencyTest {
                          // Ignore the methods only available in HttpHeaderGetters or HttpHeadersBuilder.
                          if ("endOfStream".equals(methodName) ||
                              "isEndOfStream".equals(methodName) ||
+                             "contentLength".equals(methodName) ||
                              "contentType".equals(methodName) ||
                              "contentDisposition".equals(methodName)) {
                              return false;

--- a/examples/proxy-server/src/main/java/example/armeria/proxy/AnimationService.java
+++ b/examples/proxy-server/src/main/java/example/armeria/proxy/AnimationService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpResponseWriter;
@@ -63,8 +62,9 @@ public final class AnimationService extends AbstractHttpService {
     protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         // Create a response for streaming. If you don't need to stream, use HttpResponse.of(...) instead.
         final HttpResponseWriter res = HttpResponse.streaming();
-        res.write(ResponseHeaders.of(HttpStatus.OK,
-                                     HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8));
+        res.write(ResponseHeaders.builder(HttpStatus.OK)
+                                 .contentType(MediaType.PLAIN_TEXT_UTF_8)
+                                 .build());
         res.whenConsumed().thenRun(() -> streamData(ctx.eventLoop(), res, 0));
         return res;
     }

--- a/examples/saml-service-provider/src/main/java/example/armeria/server/saml/sp/MyAuthHandler.java
+++ b/examples/saml-service-provider/src/main/java/example/armeria/server/saml/sp/MyAuthHandler.java
@@ -80,11 +80,11 @@ final class MyAuthHandler implements Authorizer<HttpRequest>, SamlSingleSignOnHa
                                     .maxAge(60)
                                     .path("/")
                                     .build();
-        return HttpResponse.of(
-                ResponseHeaders.of(HttpStatus.OK,
-                                   HttpHeaderNames.CONTENT_TYPE, MediaType.HTML_UTF_8,
-                                   HttpHeaderNames.SET_COOKIE, cookie.toSetCookieHeader(false)),
-                HttpData.ofUtf8("<html><body onLoad=\"window.location.href='/welcome'\"></body></html>"));
+        return HttpResponse.of(ResponseHeaders.builder(HttpStatus.OK)
+                                              .contentType(MediaType.HTML_UTF_8)
+                                              .cookies(cookie).build(),
+                               HttpData.ofUtf8(
+                                       "<html><body onLoad=\"window.location.href='/welcome'\"></body></html>"));
     }
 
     /**

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -31,7 +31,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -306,7 +305,7 @@ final class UnframedGrpcService extends SimpleDecoratingHttpService implements G
             public void onNext(DeframedMessage message) {
                 // We know that we don't support compression, so this is always a ByteBuf.
                 final HttpData unframedContent = HttpData.wrap(message.buf()).withEndOfStream();
-                unframedHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, unframedContent.length());
+                unframedHeaders.contentLength(unframedContent.length());
                 res.complete(HttpResponse.of(unframedHeaders.build(), unframedContent));
             }
 

--- a/oauth2/src/main/java/com/linecorp/armeria/internal/common/auth/oauth2/AbstractOAuth2Request.java
+++ b/oauth2/src/main/java/com/linecorp/armeria/internal/common/auth/oauth2/AbstractOAuth2Request.java
@@ -140,7 +140,7 @@ public abstract class AbstractOAuth2Request<T> {
         } else {
             requestFormData = requestFormData.withMutations(this::addCredentialsAsBodyParameters);
         }
-        headersBuilder.addObject(HttpHeaderNames.CONTENT_TYPE, MediaType.FORM_DATA);
+        headersBuilder.contentType(MediaType.FORM_DATA);
 
         return HttpRequest.of(headersBuilder.build(), HttpData.ofUtf8(requestFormData.toQueryString()));
     }

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyService.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyService.java
@@ -157,8 +157,8 @@ public final class ResteasyService<T> implements HttpService {
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
         final RequestHeaders headers = req.headers();
-        final Long contentLength = headers.getLong(HttpHeaderNames.CONTENT_LENGTH);
-        if (contentLength != null && contentLength <= maxRequestBufferSize) {
+        final long contentLength = headers.contentLength();
+        if (contentLength >= -1 && contentLength <= maxRequestBufferSize) {
             // aggregate bounded requests
             return HttpResponse.from(req.aggregate().thenCompose(r -> serveAsync(ctx, r)));
         } else {

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
@@ -112,7 +112,7 @@ abstract class AbstractSubscriber implements Subscriber<HttpObject> {
                     headers.forEach(header -> responseBuilder.addHeader(header.getKey().toString(),
                                                                         header.getValue()));
                     contentType = headers.get(HttpHeaderNames.CONTENT_TYPE);
-                    contentLength = headers.getLong(HttpHeaderNames.CONTENT_LENGTH, NO_CONTENT_LENGTH);
+                    contentLength = headers.contentLength();
                 }
                 break;
             case WAIT_DATA_OR_TRAILERS:

--- a/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
+++ b/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
@@ -229,7 +229,7 @@ final class WebOperationService implements HttpService {
             final long length = resource.contentLength();
             final ResponseHeadersBuilder headers = ResponseHeaders.builder(status);
             headers.contentType(contentType);
-            headers.setLong(HttpHeaderNames.CONTENT_LENGTH, length);
+            headers.contentLength(length);
             headers.setTimeMillis(HttpHeaderNames.LAST_MODIFIED, resource.lastModified());
             if (filename != null) {
                 headers.set(HttpHeaderNames.CONTENT_DISPOSITION,

--- a/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -525,7 +525,7 @@ public abstract class TomcatService implements HttpService {
         final long contentLength = coyoteRes.getBytesWritten(true); // 'true' will trigger flush.
         final String method = coyoteRes.getRequest().method().toString();
         if (!"HEAD".equals(method)) {
-            headers.setLong(HttpHeaderNames.CONTENT_LENGTH, contentLength);
+            headers.contentLength(contentLength);
         }
 
         final MimeHeaders cHeaders = coyoteRes.getMimeHeaders();

--- a/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
+++ b/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/TomcatService.java
@@ -124,8 +124,10 @@ public abstract class TomcatService implements HttpService {
     }
 
     private static final ResponseHeaders INVALID_AUTHORITY_HEADERS =
-            ResponseHeaders.of(HttpStatus.BAD_REQUEST,
-                               HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8);
+            ResponseHeaders.builder(HttpStatus.BAD_REQUEST)
+                           .contentType(MediaType.PLAIN_TEXT_UTF_8)
+                           .build();
+
     private static final HttpData INVALID_AUTHORITY_DATA =
             HttpData.ofUtf8(HttpStatus.BAD_REQUEST + "\nInvalid authority");
 


### PR DESCRIPTION
Motivation:

The main GraphQL implementations for Scala are:
- https://sangria-graphql.github.io
- https://github.com/ghostdogpr/caliban
Unfortunately, they do not depend on GraphQL-Java unlike GraphQL-Kotlin.
Actually, it is difficult to directly use GraphQL-Java in Scala without
an integration layer.

For better supporting other JVM languages, it should be nice to add a
Sangria interop layer.

Modifications:

- Add `AstractGraphqlService` that handles GraphQL over HTTP protocol.
- Make `DefaultGraphqlService` extend `AbstractGraphqlService`.
- Add `GraphqlRequest` that contains GraphQL parameters such as a raw
  `query`, `operationName`, `variables`.
- Add `armeria-sangria` module
  - Add `SangriaGraphqlService` and `SangriaGraphqlServiceBulder` that
    support GraphQL with Sangria.
  - Fork `SangriaJackson` that marshalls between Scala class and Jackson
    JsonNode.
- Add `graphql-sangria` example.
- Miscellaneous)
  - Add `scala.gradle` for configuring Gradle projects for Scala
  - Clean up the existing Gradle files of Scala projects

Result:

- A new module `armeria-sangria` integrates with
  [Sangria GraphQL](https://sangria-graphql.github.io) to let you
  serve a GraphQL request in Scala.
  ```scala
  val schema: Schema[CharacterRepo, Unit] = Schema(Query)
  Server.builder()
        .service("/graphql,
            SangriaGraphqlService.builder(schema, new CharacterRepo)
                                          .enableTracing(true)
                                          .maxQueryDepth(10)
                                          .build())
  ```
- Closes #3703Motivation:

Explain why you're making this change and what problem you're trying to solve.

Modifications:

- List the modifications you've made in detail.

Result:

- Closes #<GitHub issue number>. (If this resolves the issue.)
- Describe the consequences that a user will face after this PR is merged.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
Motivation:

Currently, HttpHeaders internally holds headers as string values.
An object set via shortcut methods is not cached and deserialze from
the string value.
See #3711 for details.

Modifications:

- Cache the original values which have shortcut methods in
 `HttpHeadersBase`
  - `HttpMethod`
  - `HttpStatus`
  - `MediaType` for `Content-Type`
  - `ContentDisposition`
  - `List<LanguageRange>` for `Accept-Language`
  - `Cookies` for `Set-Cookie` and `Cookie`
- Invalidate a cached value if a value associated with the cache value
  is mutated.
- Remove cached values from `DefaultResponseHeaders` and
  `DefaultRequestHeaders`

Result:

- `HttpHeaders` now properly caches well-known HTTP header objects.
- Closes #3711