### PR TITLE
Automatically publish the Armeria site using GitHub Actions

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,0 +1,55 @@
+name: Publish Armeria site
+
+on:
+  push:
+    tags:
+      - armeria-*
+
+jobs:
+  publish-site:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install svgbob_cli
+        run: |
+          sudo apt-get -y install cargo && cargo install svgbob_cli
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - id: setup-jdk-17
+        name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Restore the cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/wrapper
+            ~/.gradle/caches
+          key: build-${{ matrix.java }}-${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('gradle.properties', 'gradle/wrapper/gradle-wrapper.properties', '**/build.gradle', 'dependencies.yml', '*/package-lock.json') }}
+          restore-keys: |
+            build-${{ matrix.java }}-${{ runner.os }}-${{ secrets.CACHE_VERSION }}-
+            build-${{ matrix.java }}-${{ runner.os }}-
+
+      - name: Build the site
+        run: |
+          ./gradlew --no-daemon --stacktrace  --max-workers=2 --parallel site
+        shell: bash
+
+      - name: Deploy the site
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site/public
+
+      - name: Clean up the cache
+        run: |
+          rm -fr ~/.gradle/caches/[0-9]* || true
+          rm -fr ~/.gradle/caches/journal-* || true
+          rm -fr ~/.gradle/caches/transforms-* || true
+          rm -f ~/.gradle/caches/*/*.lock || true
+          rm -f ~/.gradle/caches/*/gc.properties || true
+        shell: bash


### PR DESCRIPTION
Motivation:

As a part of the automation of release process, I want to automatically
update https://armeria.dev when a new version is released.

Modifications:

- Add a new GitHub Actions job that deploys the Armeria site
  using https://github.com/peaceiris/actions-gh-pages

Result:

One more step to release automation.
