### PR TITLE
Add a stale bot

### DIFF
--- a/.github/workflows/pr-stale.yml
+++ b/.github/workflows/pr-stale.yml
@@ -1,0 +1,19 @@
+name: 'Close stale issues and PR'
+on:
+  schedule:
+    # Update at 10:00 AM UTC+9
+    - cron: '0 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity.'
+          # Mark PRs as stale if they are open and inactive for 45 days.
+          days-before-pr-stale: 45
+          # Do not mark issues as stale.
+          days-before-issue-stale: -1
+          # We don't want to close PRs automatically.
+          days-before-close: -1


### PR DESCRIPTION
Motivation:

There are many PRs which are open but stale. Possible reasons for the stale would be:
- An appropriate solution for a problem could not be found; or
- Maintainers or contributors are busy.
- A PR depends on other PRs or a library patch.

In order to separate and manage old PRs more systematically, it would be a good idea to add `stale` label to the PR.

For PRs marked as stale, maintainers will determine whether to close the PR or modify it by themselves.

Modifications:

- Add a stale bot that marks inactive PRs for 60 days
- Auto-close is disabled.
- Don't mark issues as stale.

Result:

A stale bot is working in the Armeria repository on a daily basis.

Motivation:

Explain why you're making this change and what problem you're trying to solve.

Modifications:

- List the modifications you've made in detail.

Result:

- Closes #<GitHub issue number>. (If this resolves the issue.)
- Describe the consequences that a user will face after this PR is merged.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
